### PR TITLE
Fix path handling for clue images

### DIFF
--- a/jeopardy.py
+++ b/jeopardy.py
@@ -38,7 +38,11 @@ def load_rounds(path):
             val = int(row["value"] or 0)
             clue = row["clue"].strip()
             ans  = row["answer"].strip()
-            img  = row.get("image","").strip()
+            img  = row.get("image", "").strip()
+            # Normalize image path so clients can fetch from our /static folder
+            if img:
+                img = os.path.basename(img)
+                img = f"/static/{img}"
             rounds.setdefault(rnd, OrderedDict())
             rounds[rnd].setdefault(cat, {})[val] = {
                 "text": clue, "answer": ans, "image": img, "value": val


### PR DESCRIPTION
## Summary
- normalize image paths when loading the CSV so images under `/static` display correctly

## Testing
- `python3 -m py_compile jeopardy.py`


------
https://chatgpt.com/codex/tasks/task_e_68480f42119c8323a0c506130a0ec71d