### PR TITLE
Improve LAN accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Jeopardy LAN Setup
+
+This project runs a local Jeopardy game using Flask and Socket.IO.
+
+1. Run the server with `python3 jeopardy.py`.
+2. The console will display the server address, e.g. `http://192.168.1.50:5050`.
+   Share this address with players on the same Wi-Fi/LAN.
+3. Players visit `http://<server-ip>:5050/` and the host visits
+   `http://<server-ip>:5050/host`.
+
+Use the displayed IP instead of `127.0.0.1` so other devices can connect.

--- a/jeopardy.py
+++ b/jeopardy.py
@@ -330,7 +330,22 @@ def broadcast_scores():
     lst.sort(key=lambda x: -x["score"])
     socketio.emit("scores", lst)
 
+def _get_local_ip():
+    """Return the best guess of this machine's LAN IPv4 address."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        # This doesn't actually have to reach the address; it just determines
+        # the outbound interface and hence our local address.
+        s.connect(("10.255.255.255", 1))
+        ip = s.getsockname()[0]
+    except Exception:
+        ip = "127.0.0.1"
+    finally:
+        s.close()
+    return ip
+
+
 if __name__ == "__main__":
-    host_ip = socket.gethostbyname(socket.gethostname())
+    host_ip = _get_local_ip()
     print(f"★ Jeopardy server running at http://{host_ip}:{PORT}")
     socketio.run(app, host="0.0.0.0", port=PORT)


### PR DESCRIPTION
## Summary
- show best-guess LAN IP when starting server
- document how to join game from other devices

## Testing
- `pip install flask flask_socketio` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685101e7460c83239fd0854e6623c172