### PR TITLE
Clarify HTTP usage for LAN players

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ This project runs a local Jeopardy game using Flask and Socket.IO.
    `http://<server-ip>:5050/host`.
 
 Use the displayed IP instead of `127.0.0.1` so other devices can connect.
+
+**Troubleshooting:** If your browser says it can't establish a secure connection,
+make sure the address begins with `http://` (not `https://`). Some browsers
+automatically try HTTPS which this simple local server does not support.

--- a/jeopardy.py
+++ b/jeopardy.py
@@ -347,5 +347,7 @@ def _get_local_ip():
 
 if __name__ == "__main__":
     host_ip = _get_local_ip()
-    print(f"★ Jeopardy server running at http://{host_ip}:{PORT}")
+    url = f"http://{host_ip}:{PORT}"
+    print(f"★ Jeopardy server running at {url}")
+    print("Open this exact URL on all devices. If your browser insists on a secure connection, ensure the address begins with 'http://'.")
     socketio.run(app, host="0.0.0.0", port=PORT)


### PR DESCRIPTION
## Summary
- add note explaining browsers might try HTTPS and fail
- print reminder to use the HTTP URL when running the server

## Testing
- `python3 -m py_compile jeopardy.py`

------
https://chatgpt.com/codex/tasks/task_e_6851043381ac8323a6d59849a09d6716