### PR TITLE
Fix final Jeopardy answer review

### DIFF
--- a/host.html
+++ b/host.html
@@ -213,14 +213,21 @@
     document.getElementById('finalInstructions').style.display = 'block';
   });
 
-  // CLOSE WAGERS & SCHEDULE REVIEW BUTTON
+  // CLOSE WAGERS
   function closeWagers(){
     socket.emit('close_wagers');
-    document.getElementById('closeWagersBtn').disabled=true;
-    socket.once('final_timer', ()=>{
-      document.getElementById('startReviewBtn').style.display='inline-block';
-    });
+    document.getElementById('closeWagersBtn').disabled = true;
+    const btn=document.getElementById('startReviewBtn');
+    btn.style.display='inline-block';
+    btn.disabled=true;
   }
+
+  // Enable answer review button when timer ends
+  socket.on('enable_review', ()=>{
+    const btn=document.getElementById('startReviewBtn');
+    btn.style.display='inline-block';
+    btn.disabled=false;
+  });
 
   socket.on('final_clue', d=>{
     document.getElementById('clueArea').innerHTML=


### PR DESCRIPTION
## Summary
- fix host-side event handling for Final Jeopardy review
- show review button only after answers lock

## Testing
- `python3 -m py_compile jeopardy.py`


------
https://chatgpt.com/codex/tasks/task_e_68539957f39483238316afbdab4fba79