### PR TITLE
Fix final timer enable flag

### DIFF
--- a/host.html
+++ b/host.html
@@ -70,8 +70,9 @@
   let boardLocked = false;
   let boardData   = JSON.parse(document.getElementById('board').dataset.board);
   const socket    = io();
-
-  socket.emit('register_host');
+  socket.on('connect', ()=>{
+    socket.emit('register_host');
+  });
 
   // NAV / ROUND CONTROLS
   function updateNavButtons(){

--- a/jeopardy.py
+++ b/jeopardy.py
@@ -9,7 +9,7 @@
 
 from flask import Flask, render_template, request
 from flask_socketio import SocketIO, emit, join_room
-from time import time, sleep
+from time import time
 import socket, os, csv
 from collections import OrderedDict
 
@@ -187,7 +187,7 @@ def passthrough_mark_used(data):
     emit("mark_used", data, room=HOSTS_ROOM)
 
 def after_reading_open_buzzers():
-    sleep(READING_TIME)
+    socketio.sleep(READING_TIME)
     open_buzzers()
 
 def open_buzzers():
@@ -275,7 +275,7 @@ def handle_close_wagers():
     socketio.start_background_task(_notify_review_ready)
 
 def _notify_review_ready():
-    sleep(FINAL_TIMER)
+    socketio.sleep(FINAL_TIMER)
     socketio.emit("enable_review", room=HOSTS_ROOM)
 
 @socketio.on("submit_answer")


### PR DESCRIPTION
## Summary
- use cooperative sleep calls in jeopardy timer threads

## Testing
- `python3 -m py_compile jeopardy.py`


------
https://chatgpt.com/codex/tasks/task_e_6853a5157144832399e5405f70753ee6